### PR TITLE
Only deploy through Travis on Master

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+/build

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,11 @@ sudo: false
 cache: bundler
 notifications:
   email: false
-after_success:
-- bundle exec rake deploy
+deploy:
+  provider: script
+  script: deploy.sh
+  on:
+    branch: master
 env:
   global:
   - secure: nGQ3/GEw9PcV5GMe1kGEWYfrqhNUqbe58Eslb+uZSSgax4RcdLyzyqJ90ieUzW4KwxPKkhsNpKKIuj9QSsaQOjl2YrUPGNU1pw9qbQWak4Nb56oF/pkKmphA76x0Ek3Vz2I7VD88xJGIgE+G+Rb2QWhGCWsmXW/3TtQYjxAynGw=

--- a/app.rb
+++ b/app.rb
@@ -5,6 +5,8 @@ require 'sinatra-index'
 configure do
   register Sinatra::Index
   use_static_index 'index.html'
+
+  set :public_folder, proc { File.join(root, "build") }
 end
 
 get '/hello/' do

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,1 @@
+bundle exec rake deploy


### PR DESCRIPTION
This used to be just an `after_success` hook, but the [custom script provider](http://docs.travis-ci.com/user/deployment/script/) allows to limit the branch.
